### PR TITLE
Bug fix set default color scheme

### DIFF
--- a/projects/ngx-beautiful-charts/package.json
+++ b/projects/ngx-beautiful-charts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-beautiful-charts",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "A library to create charts in Angular",
   "peerDependencies": {
     "@angular/common": "^8.0.1",

--- a/projects/ngx-beautiful-charts/src/lib/donut-chart/donut-chart.component.ts
+++ b/projects/ngx-beautiful-charts/src/lib/donut-chart/donut-chart.component.ts
@@ -13,7 +13,7 @@ export class DonutChartComponent implements OnInit, OnChanges {
 
   @Input() data: [{name: string, color: string, value: number }];
   @Input() width: number;
-  @Input() colorScheme: string;
+  @Input() colorScheme = 'colorful';
   @Input() customColorScheme: string[] = [];
 
   componentID;

--- a/projects/ngx-beautiful-charts/src/lib/line-graph/line-graph.component.ts
+++ b/projects/ngx-beautiful-charts/src/lib/line-graph/line-graph.component.ts
@@ -16,7 +16,7 @@ export class LineGraphComponent implements OnInit, OnChanges {
   @Input() width: number;
   @Input() height: number;
   @Input() color: string;
-  @Input() colorScheme: string;
+  @Input() colorScheme = 'colorful';
   @Input() minX: number = null;
   @Input() minY: number = null;
   @Input() maxX: number = null;

--- a/projects/ngx-beautiful-charts/src/lib/multi-line-graph/multi-line-graph.component.ts
+++ b/projects/ngx-beautiful-charts/src/lib/multi-line-graph/multi-line-graph.component.ts
@@ -15,7 +15,7 @@ export class MultiLineGraphComponent implements OnInit, OnChanges {
   @Input() data: [{name: string, color: string, data: [{x: number, y: number, info: any }]}];
   @Input() width: number;
   @Input() height: number;
-  @Input() colorScheme: string;
+  @Input() colorScheme = 'colorful';
   @Input() minX: number = null;
   @Input() minY: number = null;
   @Input() maxX: number = null;

--- a/projects/ngx-beautiful-charts/src/lib/pie-chart/pie-chart.component.ts
+++ b/projects/ngx-beautiful-charts/src/lib/pie-chart/pie-chart.component.ts
@@ -17,7 +17,7 @@ export class PieChartComponent implements OnInit, OnChanges {
 
   @Input() data: [{name: string, color: string, value: number }];
   @Input() width: number;
-  @Input() colorScheme: string;
+  @Input() colorScheme = 'colorful';
   @Input() customColorScheme: string[] = [];
 
   componentID;


### PR DESCRIPTION
Set default color scheme to "colorful" for charts that didn't have that set. This was causing errors if color wasn't set when using the component.